### PR TITLE
Berks stalls on chefignore conflict on a new cookbok

### DIFF
--- a/lib/souschef/berkshelf.rb
+++ b/lib/souschef/berkshelf.rb
@@ -29,10 +29,10 @@ module Souschef
     # Returns String
     def berks_cmd
       if @opts[:path] == Dir.pwd
-        "#{which_berks} cookbook #{@opts[:cookbook]} ."
+        "yes | #{which_berks} cookbook #{@opts[:cookbook]} ."
       else
         path = @opts[:path].gsub("#{Dir.pwd}/", '')
-        "#{which_berks} cookbook #{@opts[:cookbook]} #{path}"
+        "yes | #{which_berks} cookbook #{@opts[:cookbook]} #{path}"
       end
     end
 

--- a/lib/souschef/version.rb
+++ b/lib/souschef/version.rb
@@ -1,4 +1,4 @@
 # Souschef version
 module Souschef
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end


### PR DESCRIPTION
```
berks cookbook oomg
      create  oomg/files/default
      create  oomg/templates/default
      create  oomg/attributes
      create  oomg/libraries
      create  oomg/providers
      create  oomg/recipes
      create  oomg/resources
      create  oomg/recipes/default.rb
      create  oomg/metadata.rb
      create  oomg/LICENSE
      create  oomg/README.md
      create  oomg/CHANGELOG.md
      create  oomg/Berksfile
      create  oomg/Thorfile
      create  oomg/chefignore
      create  oomg/.gitignore
      create  oomg/Gemfile
      create  .kitchen.yml
    conflict  chefignore
Overwrite /home/antun/test/oomg/chefignore? (enter "h" for help) [Ynaqdh]
```